### PR TITLE
Feat: 리뷰 사진 모아보기 컴포넌트 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,7 +50,8 @@
     "@typescript-eslint/no-floating-promises": 0,
     "react/require-default-props": 0,
     "react/button-has-type": 0,
-    "react/no-unknown-property": ["error", { "ignore": ["css"] }]
+    "react/no-unknown-property": ["error", { "ignore": ["css"] }],
+    "react/jsx-no-useless-fragment": 0
   },
   "settings": {
     "import/resolver": {

--- a/components/shared/ImageWrap/ImageWrap.styled.tsx
+++ b/components/shared/ImageWrap/ImageWrap.styled.tsx
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.div<{ percent: number }>`
+  position: relative;
+  width: ${props => `${props.percent}%`};
+
+  ::after {
+    display: block;
+    content: "";
+    padding-bottom: 100%;
+  }
+
+  img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 4px;
+  }
+`;

--- a/components/shared/ImageWrap/ImageWrap.tsx
+++ b/components/shared/ImageWrap/ImageWrap.tsx
@@ -1,0 +1,10 @@
+import * as S from "./ImageWrap.styled";
+
+interface IImageWrap {
+  percent: number;
+  children: string | JSX.Element | JSX.Element[];
+}
+
+export default function ImageWrap({ percent, children }: IImageWrap) {
+  return <S.Container percent={percent}>{children}</S.Container>;
+}

--- a/components/store/review/CountTitle/CountTitle.styled.tsx
+++ b/components/store/review/CountTitle/CountTitle.styled.tsx
@@ -1,0 +1,14 @@
+import styled from "@emotion/styled";
+
+export const CountTitle = styled.div`
+  height: 1.9rem;
+  line-height: 1.9rem;
+  font-size: ${({ theme }) => theme.fontSizes[16]};
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.black};
+  margin-bottom: 1.6rem;
+
+  span {
+    color: ${({ theme }) => theme.colors.primary};
+  }
+`;

--- a/components/store/review/CountTitle/CountTitle.tsx
+++ b/components/store/review/CountTitle/CountTitle.tsx
@@ -1,0 +1,14 @@
+import * as S from "./CountTitle.styled";
+
+interface ICountTitle {
+  tag: string;
+  count: number;
+}
+
+export default function CountTitle({ tag, count }: ICountTitle) {
+  return (
+    <S.CountTitle>
+      {tag} <span>{count}</span>건
+    </S.CountTitle>
+  );
+}

--- a/components/store/review/Preview/Preview.styled.tsx
+++ b/components/store/review/Preview/Preview.styled.tsx
@@ -11,27 +11,6 @@ export const PreviewImages = styled.div`
   gap: 0.4rem;
 `;
 
-export const ImageWrap = styled.div`
-  position: relative;
-  width: 25%;
-
-  ::after {
-    display: block;
-    content: "";
-    padding-bottom: 100%;
-  }
-
-  img {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: 4px;
-  }
-`;
-
 export const ShowMore = styled.div`
   display: flex;
   align-items: center;

--- a/components/store/review/Preview/Preview.styled.tsx
+++ b/components/store/review/Preview/Preview.styled.tsx
@@ -1,0 +1,50 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.div`
+  display: block;
+`;
+
+export const PreviewImages = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  gap: 0.4rem;
+`;
+
+export const ImageWrap = styled.div`
+  position: relative;
+  width: 25%;
+
+  ::after {
+    display: block;
+    content: "";
+    padding-bottom: 100%;
+  }
+
+  img {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 4px;
+  }
+`;
+
+export const ShowMore = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+
+  font-size: ${({ theme }) => theme.fontSizes[12]};
+  font-weight: 500;
+  line-height: 1.4rem;
+
+  color: ${({ theme }) => theme.colors.white[100]};
+  background-color: rgba(32, 32, 32, 0.6);
+  width: 100%;
+  height: 100%;
+  border-radius: 4px;
+`;

--- a/components/store/review/Preview/Preview.tsx
+++ b/components/store/review/Preview/Preview.tsx
@@ -1,0 +1,37 @@
+import Image from "next/image";
+import Icon from "@/components/shared/Icon/Icon";
+import CountTitle from "../CountTitle/CountTitle";
+import * as S from "./Preview.styled";
+
+interface IReviewImages {
+  reviewImages: {
+    id: number;
+    url: string;
+  }[];
+}
+
+const REVIEW = "리뷰";
+const IMAGE = "이미지";
+const SHOWMORE = "더보기";
+
+export default function Preview({ reviewImages }: IReviewImages) {
+  const previewImages = reviewImages.slice(0, 4);
+
+  return (
+    <S.Container>
+      <CountTitle tag={REVIEW} count={reviewImages.length} />
+      <S.PreviewImages>
+        {previewImages.map((image, idx) => (
+          <S.ImageWrap key={image.url}>
+            <Image src={image.url} width={79} height={79} alt={IMAGE} />
+            {idx === previewImages.length - 1 && (
+              <S.ShowMore>
+                {SHOWMORE} <Icon name="arrowRight" size="xs" color="#fff" />
+              </S.ShowMore>
+            )}
+          </S.ImageWrap>
+        ))}
+      </S.PreviewImages>
+    </S.Container>
+  );
+}

--- a/components/store/review/Preview/Preview.tsx
+++ b/components/store/review/Preview/Preview.tsx
@@ -1,6 +1,8 @@
+import { useRouter } from "next/router";
+import Link from "next/link";
 import Image from "next/image";
 import Icon from "@/components/shared/Icon/Icon";
-import CountTitle from "../CountTitle/CountTitle";
+import CountTitle from "@/components/store/review/CountTitle/CountTitle";
 import * as S from "./Preview.styled";
 
 interface IReviewImages {
@@ -15,6 +17,8 @@ const IMAGE = "이미지";
 const SHOWMORE = "더보기";
 
 export default function Preview({ reviewImages }: IReviewImages) {
+  const { asPath } = useRouter();
+
   const previewImages = reviewImages.slice(0, 4);
 
   return (
@@ -25,9 +29,11 @@ export default function Preview({ reviewImages }: IReviewImages) {
           <S.ImageWrap key={image.url}>
             <Image src={image.url} width={79} height={79} alt={IMAGE} />
             {idx === previewImages.length - 1 && (
-              <S.ShowMore>
-                {SHOWMORE} <Icon name="arrowRight" size="xs" color="#fff" />
-              </S.ShowMore>
+              <Link href={`${asPath}/images`}>
+                <S.ShowMore>
+                  {SHOWMORE} <Icon name="arrowRight" size="xs" color="#fff" />
+                </S.ShowMore>
+              </Link>
             )}
           </S.ImageWrap>
         ))}

--- a/components/store/review/Preview/Preview.tsx
+++ b/components/store/review/Preview/Preview.tsx
@@ -2,6 +2,7 @@ import { useRouter } from "next/router";
 import Link from "next/link";
 import Image from "next/image";
 import Icon from "@/components/shared/Icon/Icon";
+import ImageWrap from "@/components/shared/ImageWrap/ImageWrap";
 import CountTitle from "@/components/store/review/CountTitle/CountTitle";
 import * as S from "./Preview.styled";
 
@@ -26,16 +27,18 @@ export default function Preview({ reviewImages }: IReviewImages) {
       <CountTitle tag={REVIEW} count={reviewImages.length} />
       <S.PreviewImages>
         {previewImages.map((image, idx) => (
-          <S.ImageWrap key={image.url}>
+          <ImageWrap key={image.url} percent={25}>
             <Image src={image.url} width={79} height={79} alt={IMAGE} />
-            {idx === previewImages.length - 1 && (
+            {idx === previewImages.length - 1 ? (
               <Link href={`${asPath}/images`}>
                 <S.ShowMore>
                   {SHOWMORE} <Icon name="arrowRight" size="xs" color="#fff" />
                 </S.ShowMore>
               </Link>
+            ) : (
+              <></>
             )}
-          </S.ImageWrap>
+          </ImageWrap>
         ))}
       </S.PreviewImages>
     </S.Container>

--- a/pages/store/[storeId]/review/all.page.tsx
+++ b/pages/store/[storeId]/review/all.page.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import OverallStats from "@/components/store/review/OverallStats/OverallStats";
 import ReviewFilter from "@/components/ReviewFilter/ReviewFilter";
 import Review from "@/components/store/review/Review/Review";
+import Preview from "@/components/store/review/Preview/Preview";
 import { reviews } from "@/mocks/mockData/review";
 import * as S from "./review.styled";
 
@@ -9,6 +10,7 @@ function ReviewsPage() {
   const [filterClicked, setFilterClicked] = useState("all");
   const [filteredReviews, setFilteredReviews] = useState(reviews.reviewList);
   const { rating, totalReviews, stats } = reviews.overallStats;
+  const reviewImages = reviews.reviewList.map(review => review.reviewImages).flat();
 
   useEffect(() => {
     const filtered = reviews.reviewList.filter(review => {
@@ -20,6 +22,9 @@ function ReviewsPage() {
   return (
     <S.Container>
       <OverallStats rating={rating} totalReviews={totalReviews} stats={stats} />
+      <S.PreviewWrap>
+        <Preview reviewImages={reviewImages} />
+      </S.PreviewWrap>
       <S.ReviewListWrap>
         <ReviewFilter filterClicked={filterClicked} setFilterClicked={setFilterClicked} />
         {filteredReviews.map(review => (

--- a/pages/store/[storeId]/review/all/images.page.tsx
+++ b/pages/store/[storeId]/review/all/images.page.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable react/no-array-index-key */
+import Image from "next/image";
+import { reviews } from "@/mocks/mockData/review"; // TODO: 나중에 바꿔야 함
+import ImageWrap from "@/components/shared/ImageWrap/ImageWrap";
+import CountTitle from "@/components/store/review/CountTitle/CountTitle";
+import * as S from "./images.styled";
+
+const IMAGES = "이미지";
+
+export default function ImagesPage() {
+  const reviewImages = reviews.reviewList.map(review => review.reviewImages).flat();
+
+  return (
+    <S.Container>
+      <CountTitle tag={IMAGES} count={reviewImages.length} />
+      <S.Images>
+        {reviewImages.map((image, idx) => (
+          // eslint-disable-next-line react/jsx-key
+          <ImageWrap key={idx} percent={32}>
+            <Image src={image.url} width={108} height={106} alt={IMAGES} />
+          </ImageWrap>
+        ))}
+      </S.Images>
+    </S.Container>
+  );
+}

--- a/pages/store/[storeId]/review/all/images.styled.tsx
+++ b/pages/store/[storeId]/review/all/images.styled.tsx
@@ -1,0 +1,14 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.div`
+  width: 100%;
+  padding: 3.2rem 1.6rem 2rem;
+`;
+
+export const Images = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 2.4rem;
+`;

--- a/pages/store/[storeId]/review/review.styled.tsx
+++ b/pages/store/[storeId]/review/review.styled.tsx
@@ -5,6 +5,11 @@ export const Container = styled.div`
   padding-bottom: 4.5rem;
 `;
 
+export const PreviewWrap = styled.div`
+  width: 100%;
+  padding: 2.4rem 1.6rem 2rem;
+`;
+
 export const ReviewListWrap = styled.div`
   width: 100%;
   padding: 3.2rem 1.6rem 2rem;


### PR DESCRIPTION
### Issue Number 


close #80 

### 작업 내역

- [x] 리뷰의 모든 사진을 렌더링한다. 
 

### PR 특이 사항

images.page.tsx에서 API를 호출할 것인지 vs `Link`로 넘길 것인지 고민해야 함 

### VIEW 
![Feb-23-2023 21-41-04](https://user-images.githubusercontent.com/68533016/220909009-f0d7140b-8671-4c9d-8473-c719cee4ab9c.gif)
