### PR TITLE
Feat: 홈피드 스토어 탭 구현

### DIFF
--- a/assets/icons/check.svg
+++ b/assets/icons/check.svg
@@ -1,0 +1,3 @@
+<svg width="current" height="current" viewBox="0 0 20 20" fill="current" xmlns="http://www.w3.org/2000/svg">
+<path d="M3 10.5L8 15L17 6" stroke="pink" stroke-width="current" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/icons/index.ts
+++ b/assets/icons/index.ts
@@ -30,6 +30,7 @@ export { default as Quote } from "./quote.svg";
 export { default as SaveBookmark } from "./save_bookmark.svg";
 export { default as Search } from "./search.svg";
 export { default as Share } from "./share.svg";
+export { default as Sort } from "./sort.svg";
 export { default as Store } from "./store.svg";
 export { default as User } from "./user.svg";
 export { default as Delete } from "./delete.svg";

--- a/assets/icons/index.ts
+++ b/assets/icons/index.ts
@@ -6,6 +6,7 @@ export { default as ArrowRight } from "./arrow-right.svg";
 export { default as ArrowUp } from "./arrow-up.svg";
 export { default as BookmarkSelected } from "./bookmark-selected.svg";
 export { default as Bookmark } from "./bookmark.svg";
+export { default as Check } from "./check.svg";
 export { default as Delivery } from "./delivery.svg";
 export { default as Ellipsis } from "./ellipsis.svg";
 export { default as Heart } from "./heart.svg";

--- a/assets/icons/sort.svg
+++ b/assets/icons/sort.svg
@@ -1,0 +1,6 @@
+<svg width="current" height="current" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 12.8L5 3.19995" stroke="current" stroke-width="current" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2.6001 4.99998L5.0001 2.59998L7.4001 4.99998" stroke="current" stroke-width="current" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11 3.19993L11 12.7999" stroke="current" stroke-width="current" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.3999 10.3999L10.9999 12.7999L8.5999 10.3999" stroke="current" stroke-width="current" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/components/shared/Card/Card.styled.tsx
+++ b/components/shared/Card/Card.styled.tsx
@@ -1,4 +1,4 @@
-import { css, SerializedStyles } from "@emotion/react";
+import { css, SerializedStyles, Theme } from "@emotion/react";
 import styled from "@emotion/styled";
 import { numberToRem } from "@/utils/util";
 import Text from "../Text/Text";
@@ -181,4 +181,14 @@ export const ContentWrap = styled.div<{ type: IContentType }>`
   display: flex;
   flex-direction: column;
   ${({ type }) => variantCSS[type]};
+`;
+
+export const storeDoubleCss = ({ colors }: Theme) => css`
+  border: 1px solid ${colors.grey[300]};
+  border-radius: 0.8rem;
+  margin-bottom: 1.6rem;
+
+  ${ContentWrap} {
+    padding: 0 1.6rem 1.6rem;
+  }
 `;

--- a/components/shared/Card/Card.tsx
+++ b/components/shared/Card/Card.tsx
@@ -16,7 +16,7 @@ interface IProp {
   canPickup?: boolean;
 }
 
-function DangdoCard({
+function Card({
   image,
   dir,
   gap,
@@ -51,4 +51,4 @@ function DangdoCard({
   );
 }
 
-export default DangdoCard;
+export default Card;

--- a/components/shared/Card/StoreDoubleCard.tsx
+++ b/components/shared/Card/StoreDoubleCard.tsx
@@ -34,6 +34,7 @@ function StoreDoubleCard({ data, isEditMode }: IProps) {
       isEditMode={isEditMode}
       canDelivery={canDelivery}
       canPickup={canPickup}
+      css={S.storeDoubleCss}
     >
       <S.ContentWrap type="storeDouble">
         <S.Store weight={600} size={16} color={colors.grey[900]}>

--- a/components/shared/Sort/Sort.styled.tsx
+++ b/components/shared/Sort/Sort.styled.tsx
@@ -1,0 +1,41 @@
+import styled from "@emotion/styled";
+import Button from "../Button/Button";
+
+export const SortContainer = styled.div`
+  position: relative;
+  width: 100%;
+  height: 2.8rem;
+  display: flex;
+  justify-content: flex-end;
+`;
+
+export const SortButton = styled(Button)`
+  height: 100%;
+  display: flex;
+  align-items: center;
+  column-gap: 0.8rem;
+`;
+
+export const SortModal = styled.div<{ isOpen: boolean }>`
+  filter: drop-shadow(0px 0px 16px rgba(0, 0, 0, 0.16));
+  border-radius: 0.8rem;
+  display: ${({ isOpen }) => (isOpen ? "flex" : "none")};
+  flex-direction: column;
+  position: absolute;
+  z-index: 200;
+  top: 4rem;
+  right: auto;
+  width: 18rem;
+  background-color: ${({ theme }) => theme.colors.grey[100]};
+
+  li:not(:last-child) {
+    border-bottom: 1px solid ${({ theme }) => theme.colors.grey[200]};
+  }
+`;
+
+export const SortItemButton = styled.button`
+  display: flex;
+  align-items: center;
+  padding-left: 1.5rem;
+  height: 4rem;
+`;

--- a/components/shared/Sort/Sort.tsx
+++ b/components/shared/Sort/Sort.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from "react";
+import { useTheme } from "@emotion/react";
+import Icon from "../Icon/Icon";
+import Text from "../Text/Text";
+import * as S from "./Sort.styled";
+
+type TSort = "추천순" | "도움되는순" | "당도높은순" | "최신순";
+
+const SORT_METHODS: TSort[] = ["추천순", "도움되는순", "당도높은순", "최신순"];
+
+function Sort() {
+  const { colors } = useTheme();
+  const [currentSortMethod, setCurrentSortMethod] = useState<TSort>(SORT_METHODS[0]);
+  const [openModal, setOpenModal] = useState(false);
+
+  const toggleOpenModal = () => {
+    setOpenModal(prev => !prev);
+  };
+
+  const changeSortMethod = (sort: TSort) => {
+    setCurrentSortMethod(sort);
+    setOpenModal(prev => !prev);
+  };
+
+  return (
+    <S.SortContainer>
+      <S.SortButton type="button" label="sort button" onClick={toggleOpenModal} shape="square">
+        <Text weight={500} color={colors.grey[800]}>
+          {currentSortMethod}
+        </Text>
+        <Icon name="sort" color={colors.grey[600]} />
+      </S.SortButton>
+      <S.SortModal isOpen={openModal}>
+        {SORT_METHODS.map(sort => (
+          <S.SortItemButton key={sort} onClick={() => changeSortMethod(sort)}>
+            <Text
+              weight={500}
+              color={currentSortMethod === sort ? colors.grey[900] : colors.grey[600]}
+            >
+              {sort}
+            </Text>
+          </S.SortItemButton>
+        ))}
+      </S.SortModal>
+    </S.SortContainer>
+  );
+}
+
+export default Sort;

--- a/pages/home/stores.page.tsx
+++ b/pages/home/stores.page.tsx
@@ -1,7 +1,38 @@
-import React from "react";
+import { css, useTheme } from "@emotion/react";
+
+import { storeList } from "@/mocks/mockData/storeList";
+import { homeTab } from "@/constants/tabs";
+
+import HomeHero from "@/components/home/HomeHero/HomeHero";
+import Tab from "@/components/shared/Tab/Tab";
+import Sort from "@/components/shared/Sort/Sort";
+import StoreDoubleCard from "@/components/shared/Card/StoreDoubleCard";
+import * as S from "./recommendation/recommendation.styled";
 
 function HomeStoresPage() {
-  return <div>HomeStoresPage</div>;
+  const { colors } = useTheme();
+
+  return (
+    <div>
+      <HomeHero />
+      <Tab
+        menuList={homeTab}
+        type="fixed"
+        target="homeTab"
+        cssProp={css`
+          --size: ${homeTab.length};
+          --selected-color: ${colors.grey[900]};
+          --color: ${colors.grey[300]};
+        `}
+      />
+      <S.ContentWrap>
+        <Sort />
+        {storeList.map(store => (
+          <StoreDoubleCard key={store.id} data={store} />
+        ))}
+      </S.ContentWrap>
+    </div>
+  );
 }
 
 export default HomeStoresPage;


### PR DESCRIPTION
### Issue Number 


close #93 

### 작업 내역


- [ ] ~필터링 버튼 구현 (UI)~ -> 필터링 모달과 같이 
- [x] 정렬 버튼 구현
     - [x] 버튼 눌렀을 경우 모달창 보여주기
     - [x] 버튼 다시 누른 경우 모달창 닫기
     - [ ] ~다른 곳 눌렀을 때 모달창 닫기~ => 후순위
- [x] 업체 카드 렌더


 

### 작업 유형

- 홈피드 스토어 탭 구현


### VIEW 


https://user-images.githubusercontent.com/72786354/222322739-fda3dc04-5bc9-4a9e-8535-cce907ee0092.mov



